### PR TITLE
Pull XO from public github releases instead of private docker image

### DIFF
--- a/.github/workflows/docker_build_push.yaml
+++ b/.github/workflows/docker_build_push.yaml
@@ -1,0 +1,28 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.PUBLIC_DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.PUBLIC_DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: massdrivercloud/provisioner-init:latest


### PR DESCRIPTION
This PR also adds the github workflow files to push to Dockerhub